### PR TITLE
EN-6219: Distillery Signature Header

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,12 @@
-cartridges/int_pixlee_sfra/cartridge/static/
+node_modules/
+cartridges/**/cartridge/static/
+coverage/
+doc/
+bin/
+codecept.conf.js
+
+webpack.config.js
+workspace/
 documentation/
+
 cartridges/int_pixlee/cartridge/scripts/pixlee/pipelets/

--- a/cartridges/int_pixlee_core/cartridge/scripts/pixlee/helpers/currencyLookupHelper.js
+++ b/cartridges/int_pixlee_core/cartridge/scripts/pixlee/helpers/currencyLookupHelper.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Logger = require('dw/system/Logger');
+
 /**
  * Returns a country code for a locale.
  *
@@ -52,12 +54,16 @@ exports.getCurrencyForLocale = function (locale) {
 
     // retrieve the map by making a web service call to Pixlee
     if (!currenciesMap) {
-        var PixleeService = require('~/cartridge/scripts/pixlee/services/PixleeService');
+        var PixleeService = require('*/cartridge/scripts/pixlee/services/PixleeService');
 
         currenciesMap = PixleeService.getCountriesMap();
 
         if (currenciesMap) {
-            require('dw/system/System').preferences.custom.PixleeCountriesMap = JSON.stringify(currenciesMap, null, 4);
+            try {
+                require('dw/system/System').preferences.custom.PixleeCountriesMap = JSON.stringify(currenciesMap, null, 4);
+            } catch (e) {
+                Logger.warn('Could not cache currencies map to system preferences (no transaction available): ' + e.message);
+            }
         }
     }
 

--- a/cartridges/int_pixlee_core/cartridge/scripts/pixlee/helpers/pixleeHelper.js
+++ b/cartridges/int_pixlee_core/cartridge/scripts/pixlee/helpers/pixleeHelper.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line no-redeclare
 /* global session */
 
 /**
@@ -60,7 +61,6 @@ exports.isTrackingAllowed = function (trackingConsent) {
     }
 
     switch (pixleeTrackingPreference.value) {
-        default:
         case 'TRACK_ALWAYS':
             return true;
         case 'TRACK_IF_NOT_OPTED_OUT':
@@ -69,6 +69,8 @@ exports.isTrackingAllowed = function (trackingConsent) {
             return trackingConsent === true; // tracking NOT allowed if trackingConsent is null
         case 'TRACK_NEVER':
             return false;
+        default:
+            return true;
     }
 };
 
@@ -109,20 +111,19 @@ function getMatchingLineItem(basket, productId) {
  */
 exports.getAddToCartEvents = function (productsAdded) {
     var ProductMgr = require('dw/catalog/ProductMgr');
-    var pixleeHelper = require('./pixleeHelper');
     var pixleeEvents = [];
 
     if (Array.isArray(productsAdded) && productsAdded.length) {
         var BasketMgr = require('dw/order/BasketMgr');
         var currentBasket = BasketMgr.getCurrentOrNewBasket();
-        var PixleeEvent = require('~/cartridge/scripts/pixlee/models/eventModel').PixleeEvent;
+        var PixleeEvent = require('*/cartridge/scripts/pixlee/models/eventModel').PixleeEvent;
+        var self = this
 
         productsAdded.forEach(function (productAdded) {
             var product = ProductMgr.getProduct(productAdded.pid);
             var pli = getMatchingLineItem(currentBasket, product.ID);
-
-            var productId = pixleeHelper.getPixleeProductId(product);
-            var productSKU = pixleeHelper.getPixleeProductSKU(product);
+            var productId = self.getPixleeProductId(product);
+            var productSKU = self.getPixleeProductSKU(product);
             var quantity = parseInt(productAdded.qty, 10);
             var price = ((pli.priceValue / pli.quantityValue) * quantity).toFixed(2);
             var currency = currentBasket.currencyCode;

--- a/cartridges/int_pixlee_core/cartridge/scripts/pixlee/models/productExportPayload.js
+++ b/cartridges/int_pixlee_core/cartridge/scripts/pixlee/models/productExportPayload.js
@@ -17,8 +17,28 @@ var Resource = require('dw/web/Resource');
 var URLUtils = require('dw/web/URLUtils');
 var CatalogMgr = require('dw/catalog/CatalogMgr');
 var Currency = require('dw/util/Currency');
-var pixleeHelper = require('*/cartridge/scripts/pixlee/helpers/pixleeHelper');
-var currencyLookupHelper = require('*/cartridge/scripts/pixlee/helpers/currencyLookupHelper');
+var pixleeHelper;
+var currencyLookupHelper;
+
+/**
+ * @returns {Object} The pixleeHelper module
+ */
+function getPixleeHelper() {
+    if (!pixleeHelper) {
+        pixleeHelper = require('*/cartridge/scripts/pixlee/helpers/pixleeHelper');
+    }
+    return pixleeHelper;
+}
+
+/**
+ * @returns {Object} The currencyLookupHelper module
+ */
+function getCurrencyLookupHelper() {
+    if (!currencyLookupHelper) {
+        currencyLookupHelper = require('*/cartridge/scripts/pixlee/helpers/currencyLookupHelper');
+    }
+    return currencyLookupHelper;
+}
 
 // Cache expensive Resource.msg calls to avoid repeated string operations
 var VERSION_HASH = (function () {
@@ -1030,7 +1050,7 @@ function getRegionalInfo(product, variantsJSON, cachedProductData) {
             var cacheKey = 'pixlee:localeCurrency:' + encodeURIComponent(currentLocale);
             var localeCurrency = RequestCache.get(cacheKey, (function (locale) {
                 return function () {
-                    return currencyLookupHelper.getCurrencyForLocale(locale);
+                    return getCurrencyLookupHelper().getCurrencyForLocale(locale);
                 };
             }(currentLocale)));
 
@@ -1190,7 +1210,7 @@ function ProductExportPayload(product, options) {
 
     this.title = product.name || '';
     this.product = {
-        sku: pixleeHelper.getPixleeProductSKU(product),
+        sku: getPixleeHelper().getPixleeProductSKU(product),
         upc: product.UPC || null,
         native_product_id: product.ID,
         regional_info: regionalInfo

--- a/cartridges/int_pixlee_core/cartridge/scripts/pixlee/services/PixleeService.js
+++ b/cartridges/int_pixlee_core/cartridge/scripts/pixlee/services/PixleeService.js
@@ -8,7 +8,7 @@ var Logger = require('dw/system/Logger');
  * Generates a signature (hash) for a payload object.
  *
  * @param {Object} payload - Payload object to generate signature for
- * @return {string} - SHA-1 hash (signature) of the payload
+ * @return {string} - Base64-encoded HMAC-SHA256 signature for the payload
  */
 function getPayloadSignature(payload) {
     var Encoding = require('dw/crypto/Encoding');
@@ -63,6 +63,7 @@ var pixleeService = LocalServiceRegistry.createService('pixlee.http.service', {
 
         if (requestObject.signature) {
             svc.addHeader('Signature', requestObject.signature);
+            svc.addHeader('Signature-Algorithm', 'hmac-sha256');
         }
 
         if (requestObject.payload) {


### PR DESCRIPTION
Main commit
- Added "Signature-Algorithm" header with "hmca-sha256"

Bugfix commit
- Fixed bug with product export due to global require using `*`
  - `*` doesn't work globally so added lazy loader functions
- This caused an additional error with trying to save custom preference outside of transaction
  - Fixed by wrapping in try/catch
- Replaced pixleeHelper being called inside itself with `var self = this`
- Replaced `~` with `*` for imports to allow overrides
- Fixed linter errors